### PR TITLE
Fix UnitedStates calendar constructor

### DIFF
--- a/ql/time/calendars/unitedstates.cpp
+++ b/ql/time/calendars/unitedstates.cpp
@@ -93,8 +93,9 @@ namespace QuantLib {
           case Settlement:
             impl_ = settlementImpl;
             break;
-        case LiborImpact:
+          case LiborImpact:
             impl_ = liborImpactImpl;
+            break;
           case NYSE:
             impl_ = nyseImpl;
             break;


### PR DESCRIPTION
Fix the `case LiborImpact` for missing `break`.